### PR TITLE
Added deactivation of cache

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -136,6 +136,8 @@ class Builder
     {
         // This will retrieve the existing instance with stale settings
         $kirby = kirby();
+        // Disable cache
+        C::set('cache', false);
         // We need to call configure again with the new url prefix
         C::set('url', static::URLPREFIX);
         $kirby->configure();


### PR DESCRIPTION
Otherwise – with activated cache – all static pages will get the content of the home page.