### PR TITLE
Added two features: zip download and better relative urls

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -4,6 +4,7 @@ namespace Kirby\StaticBuilder;
 
 use C;
 use R;
+use F;
 use Response;
 
 class Controller
@@ -48,7 +49,14 @@ class Controller
         $write = R::is('POST') and R::get('confirm');
         $site = site();
         $kirby = kirby();
+        $zipfile = kirby()->get('option', 'staticbuilder.zipfile', false);
         $builder = new Builder();
+
+        if (substr($zipfile, -4) === '.zip' and F::exists($zipfile)) {
+            $zipfile = $zipfile;
+        } else {
+            $zipfile = false;
+        }
 
         // bail if cache is active
         if ($kirby->get('option', 'cache')) {
@@ -72,6 +80,7 @@ class Controller
         return $builder->htmlReport([
             'mode'    => 'site',
             'error'   => false,
+            'zipFile' => $zipfile,
             'confirm' => $write,
             'summary' => $builder->summary
         ]);

--- a/src/report.php
+++ b/src/report.php
@@ -139,6 +139,11 @@ function makeRow($info, $base) {
         <?php if ($mode == 'page'): ?>
             <a class="header-btn" href="<?php echo $base ?>">show all pages</a>
         <?php endif; ?>
+        <?php if ($mode == 'site' && $zipFile) : ?>
+            <a href="<?= explode('staticbuilder', thisUrl())[0] , $zipFile ?>" class="header-btn" download>
+                Download Zip
+            </a>
+        <?php endif; ?>
         <?php if ($mode !== 'fatal'): ?>
             <form method="post" action="">
                 <input type="hidden" name="confirm" value="1">


### PR DESCRIPTION
**Rewrite /content URLs**
If files are copied (`c::set('staticbuilder.withfiles', true)`) links no longer refer to /content but to the parent’s target directory.
`<img src="content/1-my/3-page/image.jpg">` -> `<img src="my/page/image.jpg">`

**Create zip file**
Option for creating a zip file.
`c::set('staticbuilder.zipfile', 'archive.zip');`
